### PR TITLE
bugfix/includes-with-trailing-slash

### DIFF
--- a/examples/troubleshooting/manifest.yml
+++ b/examples/troubleshooting/manifest.yml
@@ -2,4 +2,4 @@ functions:
   initialise_tasks:
     requirements: ./requirements.txt
     include:
-      - ./src
+      - ./src/

--- a/examples/troubleshooting/manifest.yml
+++ b/examples/troubleshooting/manifest.yml
@@ -1,0 +1,5 @@
+functions:
+  initialise_tasks:
+    requirements: ./requirements.txt
+    include:
+      - ./src

--- a/examples/troubleshooting/manifest.yml
+++ b/examples/troubleshooting/manifest.yml
@@ -1,5 +1,0 @@
-functions:
-  initialise_tasks:
-    requirements: ./requirements.txt
-    include:
-      - ./src/

--- a/juniper/actions.py
+++ b/juniper/actions.py
@@ -89,10 +89,20 @@ def _get_compose_template(manifest):
 
 
 def _get_volumes(manifest, sls_function):
+    """
+    Get the docker compose volume mapping from the includes block of a serverless
+    function definition. Each entry will be mapped to its own entry in the docker
+    container.
+
+    :param manifest: The entire juniper manifest.
+    :param sls_function: The serverless function definition.
+    """
 
     def get_vol(include):
-        name = include[include.rindex('/') + 1:]
-        return f'{include}:/var/task/common/{name}'
+
+        norm_include = include.rstrip('/')
+        name = norm_include[norm_include.rindex('/') + 1:]
+        return f'{norm_include}:/var/task/common/{name}'
 
     output_dir = manifest.get('package', {}).get('output', DEFAULT_OUT_DIR)
     volumes = [

--- a/tests/expectations/custom-docker-images.yml
+++ b/tests/expectations/custom-docker-images.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - ./dist:/var/task/dist
       - ./.juni/bin:/var/task/bin
-      - ./src/edge/:/var/task/common/
+      - ./src/edge:/var/task/common/edge
       - ./src/edge/requirements.txt:/var/task/common/requirements.txt
     command: sh /var/task/bin/package.sh edge
 

--- a/tests/expectations/processor-compose.yml
+++ b/tests/expectations/processor-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./dist:/var/task/dist
       - ./.juni/bin:/var/task/bin
       - ./src/eablib/eab:/var/task/common/eab
-      - ./src/processor/:/var/task/common/
+      - ./src/processor:/var/task/common/processor
       - ./src/processor/requirements.txt:/var/task/common/requirements.txt
     command: sh /var/task/bin/package.sh processor
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -24,25 +24,6 @@ from juniper.io import reader, get_artifact_path
 logger = MagicMock()
 
 
-def test_build_compose_sections():
-    """
-    Using the processor-test as a sample definition of the lambda functions to
-    be packaged. Make sure that the resources portion of the file is correctly
-    generated.
-
-    The sections portion of the file, takes into account the volume mappings
-    as well as well as the command to invoke when docker-compose is invoked.
-    """
-
-    manifest = reader('./tests/manifests/processor-test.yml')
-    result = actions._get_compose_template(manifest)
-
-    # The fully converted docker-compose.yml file as created by the action.
-    expected = read_file('./tests/expectations/processor-sections.yml')
-
-    assert yaml.load(result) == yaml.load(expected)
-
-
 def test_build_compose_writes_compose_definition_to_tmp_file(mocker):
     """
     The docker-compose file created, is written to a tmp file. Make sure that
@@ -140,6 +121,17 @@ def test_build_compose_section_custom_output():
         for volume in yaml_result['services']['test_func-lambda']['volumes']
         if custom_output_dir in volume
     ])
+
+
+def test_get_volumes_fixes_trailing_slash():
+
+    sls_function = {'include': ['./src/function1/']}
+    manifest = {'functions': {'function1': sls_function}}
+
+    volumes = actions._get_volumes(manifest, sls_function)
+
+    expected_mapping = './src/function1:/var/task/common/function1'
+    assert expected_mapping in volumes
 
 
 def read_file(file_name):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -124,14 +124,36 @@ def test_build_compose_section_custom_output():
 
 
 def test_get_volumes_fixes_trailing_slash():
+    """
+    If the include entry contains a trailing slash, the mapped version should NOT have it.
+    """
 
     sls_function = {'include': ['./src/function1/']}
-    manifest = {'functions': {'function1': sls_function}}
+    manifest = {'functions': {'router': sls_function}}
 
     volumes = actions._get_volumes(manifest, sls_function)
 
     expected_mapping = './src/function1:/var/task/common/function1'
     assert expected_mapping in volumes
+
+
+def test_get_volumes_with_mixed_entries():
+
+    sls_function = {
+        'include': [
+            './src/common/',
+            './src/benchmark',
+            './src/trail',
+        ]
+    }
+    manifest = {'functions': {'router': sls_function}}
+
+    volumes = actions._get_volumes(manifest, sls_function)
+
+    tmpl = './src/{name}:/var/task/common/{name}'
+    assert tmpl.format(name='common') in volumes
+    assert tmpl.format(name='benchmark') in volumes
+    assert tmpl.format(name='trail') in volumes
 
 
 def read_file(file_name):


### PR DESCRIPTION
Mapping of a folder with trailing slash, causes bleed of the requirements into the user's local system.

Closes https://github.com/eabglobal/juniper/issues/24