### PR TITLE
Fix yaml.load warning

### DIFF
--- a/juniper/io.py
+++ b/juniper/io.py
@@ -24,7 +24,7 @@ import pkg_resources
 def reader(file_name):
 
     with open(file_name, 'r') as stream:
-        return yaml.load(stream)
+        return yaml.safe_load(stream)
 
 
 def write_tmp_file(content):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -40,7 +40,7 @@ def test_build_compose_writes_compose_definition_to_tmp_file(mocker):
     expected = read_file('./tests/expectations/processor-compose.yml')
 
     assert tmp_filename == actual_filename
-    assert yaml.load(mock_writer.call_args[0][0]) == yaml.load(expected)
+    assert yaml.safe_load(mock_writer.call_args[0][0]) == yaml.safe_load(expected)
 
 
 def test_build_artifacts_invokes_docker_commands(mocker):
@@ -114,7 +114,7 @@ def test_build_compose_section_custom_output():
     }
 
     result = actions._get_compose_template(manifest)
-    yaml_result = yaml.load(result)
+    yaml_result = yaml.safe_load(result)
 
     assert len([
         volume.strip()

--- a/tests/test_build_with_overrides.py
+++ b/tests/test_build_with_overrides.py
@@ -35,7 +35,7 @@ def test_build_compose_sections_custom_docker_images():
     result = actions._get_compose_template(docker_ctx)
 
     expected = read_file('./tests/expectations/custom-docker-images.yml')
-    assert yaml.load(result) == yaml.load(expected)
+    assert yaml.safe_load(result) == yaml.safe_load(expected)
 
 
 def test_get_docker_image_default():


### PR DESCRIPTION
Used safe_load which limits the ability to construct an arbitrary Python object to simple Python objects like integers or lists. Check https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml for further details