### PR TITLE
feature/create-output-dir

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,20 @@
 Juniper Changelog
 ===============
 
+Version 0.3.0
+-------------
+
+Released on April 5th 2019, codename Fondo I
+
+- Deprecating the package section as a way to override output directory. Using
+  the globals section instead.
+- Adding a new cli flag `skip-clean` as a way to control weather or not to "clean"
+  the output directory before the packaging process starts.
+- Explicitly building a new output directory. Before, we relied on the internal
+  volume mapping of the docker container as the entity that would create the output
+  directory. Now, juniper will delete and create the directory.
+
+
 Version 0.2.6
 -------------
 

--- a/README.rst
+++ b/README.rst
@@ -102,9 +102,9 @@ of the manifest. A sample configuration looks like:
         include:
         - ./src/router_function/router/lambda_function.py
 
-With this manifest, juniper will package every single lambda function using the
-docker image specified in the global section. The zip artifacts will be stored in
-the folder defined in the output section.
+Setting a docker image at a global level tells juniper to package every
+lambda function using such image. In this example, the zip artifacts will be stored in
+the ./build folder instead of the ./dist; which is the default.
 
 Features
 ********

--- a/README.rst
+++ b/README.rst
@@ -84,6 +84,28 @@ the type of images supported read `juniper and docker`_.
 
 .. _`juniper and docker`: https://eabglobal.github.io/juniper/features.html
 
+
+Configuration
+*************
+To update the default configuration of juniper, can use the the global section
+of the manifest. A sample configuration looks like:
+
+.. code-block:: yaml
+
+    global:
+      image: lambci/lambda:build-python3.7
+      output: ./build
+
+    functions:
+      router:
+        requirements: ./src/router/requirements.txt.
+        include:
+        - ./src/router_function/router/lambda_function.py
+
+With this manifest, juniper will package every single lambda function using the
+docker image specified in the global section. The zip artifacts will be stored in
+the folder defined in the output section.
+
 Features
 ********
 

--- a/examples/processing/manifest.yml
+++ b/examples/processing/manifest.yml
@@ -13,6 +13,7 @@ functions:
       - ./map_lambda/mapper
 
   reduce_step:
+    image: lambci/lambda:build-python3.7
     requirements: ./reduce_lambda/requirements.txt
     include:
-      - ./reduce_lambda/reducer
+      - ./reduce_lambda/reducer/lambda_function.py

--- a/examples/processing/reduce_lambda/requirements.txt
+++ b/examples/processing/reduce_lambda/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp
+cchardet
+aiodns

--- a/examples/single_lambda/manifest.yml
+++ b/examples/single_lambda/manifest.yml
@@ -1,9 +1,9 @@
 
-package:
+global:
   output: ./build
 
 functions:
   sample:
     requirements: ./requirements.txt
     include:
-      - ./
+      - ./lambda_function.py

--- a/examples/single_lambda/requirements.txt
+++ b/examples/single_lambda/requirements.txt
@@ -1,2 +1,2 @@
-psycopg2
+psycopg2-binary==2.7.7
 requests

--- a/juniper/__init__.py
+++ b/juniper/__init__.py
@@ -14,4 +14,4 @@
     limitations under the License.
 """
 
-__version__ = '0.2.6'
+__version__ = '0.3.0'

--- a/juniper/actions.py
+++ b/juniper/actions.py
@@ -107,7 +107,7 @@ def _get_volumes(manifest, sls_function):
         name = norm_include[norm_include.rindex('/') + 1:]
         return f'{norm_include}:/var/task/common/{name}'
 
-    output_dir = manifest.get('package', {}).get('output', DEFAULT_OUT_DIR)
+    output_dir = manifest.get('output_dir', DEFAULT_OUT_DIR)
     volumes = [
         f'{output_dir}:/var/task/dist',
         './.juni/bin:/var/task/bin',

--- a/juniper/cli.py
+++ b/juniper/cli.py
@@ -55,6 +55,11 @@ def build(manifest, debug, skip_clean):
     except FileNotFoundError as fnf:
         logger.error(str(fnf))
     else:
+        old_output = manifest_definition.get('package', {}).get('output')
+        if old_output:
+            logger.error("The package section in the manifest is deprecated. Please use the global section")
+            return
+
         # Set the value of output_dir in the manifest either from the custom value
         # provided or from the default.
         output_dir = manifest_definition.get('global', {}).get('output', DEFAULT_OUT_DIR)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'click-log',
         'PyYAML >= 3.10, < 4.3',
         'Jinja2>=2.10',
-        'docker-compose>=1.20'
+        'docker-compose>=1.20, < 1.24'
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -109,7 +109,7 @@ def test_build_compose_section_custom_output():
 
     custom_output_dir = './build_not_dist'
     manifest = {
-        'package': {'output': custom_output_dir},
+        'output_dir': custom_output_dir,
         'functions': {'test_func': {}}
     }
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,8 +14,6 @@
     limitations under the License.
 """
 
-import yaml
-
 from unittest.mock import MagicMock
 from juniper import cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,9 +42,6 @@ def test_clean_skip_false(mocker):
 
 
 def test_clean_skip_true(mocker):
-    """
-    If the skip clean flag is set to true, do nothing.
-    """
 
     mock_mkdirs = mocker.patch('os.makedirs')
     mock_rmtree = mocker.patch('shutil.rmtree')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,4 +52,4 @@ def test_clean_skip_true(mocker):
     cli._clean(logger, True, manifest)
 
     mock_rmtree.assert_not_called()
-    mock_mkdirs.assert_called_with(output_dir_name, exists_ok=True)
+    mock_mkdirs.assert_called_with(output_dir_name, exist_ok=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""
+    test_cli.py
+    :copyright: © 2019 by the EAB Tech team.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+        http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+"""
+
+import yaml
+
+from unittest.mock import MagicMock
+from juniper import cli
+
+
+logger = MagicMock()
+
+
+def test_clean_skip_false(mocker):
+    """
+    Validate that the output directory is deleted from disk.
+    Validate that a new output directory is created.
+    """
+
+    mock_mkdirs = mocker.patch('os.makedirs')
+    mock_rmtree = mocker.patch('shutil.rmtree')
+
+    output_dir_name = 'find/me/NOW'
+    manifest = {'output_dir': output_dir_name}
+
+    cli._clean(logger, False, manifest)
+
+    mock_rmtree.assert_called_with(output_dir_name, ignore_errors=True)
+    mock_mkdirs.assert_called_with(output_dir_name)
+
+
+def test_clean_skip_true(mocker):
+    """
+    If the skip clean flag is set to true, do nothing.
+    """
+
+    mock_mkdirs = mocker.patch('os.makedirs')
+    mock_rmtree = mocker.patch('shutil.rmtree')
+
+    output_dir_name = 'find/me/NOW'
+    manifest = {'output_dir': output_dir_name}
+
+    cli._clean(logger, True, manifest)
+
+    mock_rmtree.assert_not_called()
+    mock_mkdirs.assert_called_with(output_dir_name, exists_ok=True)


### PR DESCRIPTION
Before we would rely on docker to implicitly create the output directory. In some cases this could cause the error described in issue/34. To fix the issue the following enhancements are included in this PR

- Creating the output directory explicitly
- Adding `skip-clean` flag to the cli
- Deprecating the package section of the manifest in favor of using the new global section

Closes: https://github.com/eabglobal/juniper/issues/34