### PR TITLE
Feature/partial builds

### DIFF
--- a/juniper/cli.py
+++ b/juniper/cli.py
@@ -8,7 +8,7 @@ import logging
 from juniper.io import reader
 from juniper.constants import DEFAULT_OUT_DIR
 from juniper.actions import build_artifacts
-from juniper.manifest import validate_manifest_definition
+from juniper.manifest import validate_manifest_definition, filter_manifest_definition
 
 
 logger = logging.getLogger(__name__)
@@ -41,8 +41,9 @@ def main():
 @click.option('--manifest', '-m', default='manifest.yml', help='The configuration file to use.')
 @click.option('--debug', '-d', is_flag=True, help='Run the build in debug mode.')
 @click.option('--skip-clean', '-s', is_flag=True, help='Does not recreate the output directory.')
+@click.option('--function-name', '-f', help='Build one specific Lambda function defined in the manifest.')
 @click_log.simple_verbosity_option(logger)
-def build(manifest, debug, skip_clean):
+def build(manifest, debug, skip_clean, function_name):
 
     if debug:
         logger.setLevel(logging.DEBUG)
@@ -64,6 +65,10 @@ def build(manifest, debug, skip_clean):
         # provided or from the default.
         output_dir = manifest_definition.get('global', {}).get('output', DEFAULT_OUT_DIR)
         manifest_definition['output_dir'] = output_dir
+
+        # Filter the manifest if only one specific function should be built.
+        if function_name:
+            manifest_definition = filter_manifest_definition(manifest_definition, function_name)
 
         # Get the local env ready before building the artifacts.
         _clean(logger, skip_clean, manifest_definition)

--- a/juniper/cli.py
+++ b/juniper/cli.py
@@ -41,7 +41,7 @@ def main():
 @click.option('--manifest', '-m', default='manifest.yml', help='The configuration file to use.')
 @click.option('--debug', '-d', is_flag=True, help='Run the build in debug mode.')
 @click.option('--skip-clean', '-s', is_flag=True, help='Does not recreate the output directory.')
-@click.option('--function-name', '-f', help='Build one specific Lambda function defined in the manifest.')
+@click.option('--function-name', '-f', help='Build Lambda functions matching the specified name.')
 @click_log.simple_verbosity_option(logger)
 def build(manifest, debug, skip_clean, function_name):
 

--- a/juniper/cli.py
+++ b/juniper/cli.py
@@ -66,7 +66,7 @@ def build(manifest, debug, skip_clean, function_name):
         output_dir = manifest_definition.get('global', {}).get('output', DEFAULT_OUT_DIR)
         manifest_definition['output_dir'] = output_dir
 
-        # Filter the manifest if only one specific function should be built.
+        # Filter the manifest if specific functions should be built.
         if function_name:
             manifest_definition = filter_manifest_definition(manifest_definition, function_name)
 

--- a/juniper/manifest.py
+++ b/juniper/manifest.py
@@ -61,3 +61,16 @@ def all_keys(manifest_definition, key):
 
     result = [function[key] for function in manifest_definition['functions'].values()]
     return result if isinstance(result[0], str) else chain.from_iterable(result)
+
+
+def filter_manifest_definition(manifest_definition, name_filter):
+    """
+    Filters the manifest to only include the specified function.
+    :param manifest_definition: Dictionary of the manifest
+    :param name_filter: A function name specified in the manifest
+    :return: Filtered manifest definition
+    """
+    manifest_definition['functions'] = {key: value for (key, value)
+                                        in manifest_definition['functions'].items()
+                                        if key == name_filter}
+    return manifest_definition

--- a/juniper/manifest.py
+++ b/juniper/manifest.py
@@ -73,5 +73,5 @@ def filter_manifest_definition(manifest_definition, name_filter):
     """
     manifest_definition['functions'] = {key: value for (key, value)
                                         in manifest_definition['functions'].items()
-                                        if key.lower().startswith(name_filter)}
+                                        if name_filter in key.lower()}
     return manifest_definition

--- a/juniper/manifest.py
+++ b/juniper/manifest.py
@@ -65,12 +65,13 @@ def all_keys(manifest_definition, key):
 
 def filter_manifest_definition(manifest_definition, name_filter):
     """
-    Filters the manifest to only include the specified function.
+    Filters the manifest to only include functions that partially match
+    the specified filter.
     :param manifest_definition: Dictionary of the manifest
     :param name_filter: A function name specified in the manifest
     :return: Filtered manifest definition
     """
     manifest_definition['functions'] = {key: value for (key, value)
                                         in manifest_definition['functions'].items()
-                                        if key == name_filter}
+                                        if key.lower().startswith(name_filter)}
     return manifest_definition

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -16,7 +16,7 @@
 
 import pytest
 
-from juniper.manifest import validate_manifest_definition
+from juniper.manifest import validate_manifest_definition, filter_manifest_definition
 
 
 def test_source_in_manifest_does_not_exist_notifies_dev():
@@ -78,3 +78,16 @@ def test_include_section_is_required():
         validate_manifest_definition(manifest_definition)
 
     assert len(str(e))
+
+
+def test_filter_manifest_definition():
+
+    manifest_definition = {'package': {'output': './build'},
+                           'functions': {'sample': {'includes': ['./']},
+                                         'another': {'requirements': './requirements/dev.txt',
+                                                     'include': ['./']}}}
+    expected_manifest_definition = {'package': {'output': './build'},
+                                    'functions': {'sample': {'includes': ['./']}}}
+
+    actual_manifest_definition = filter_manifest_definition(manifest_definition, 'sample')
+    assert actual_manifest_definition == expected_manifest_definition

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -83,13 +83,28 @@ def test_include_section_is_required():
 def test_filter_manifest_definition():
 
     manifest_definition = {'package': {'output': './build'},
+                           'functions': {'sample': {'includes': ['./']},
+                                         'another': {'requirements': './requirements/dev.txt',
+                                                     'include': ['./']}}}
+    expected_manifest_definition = {'package': {'output': './build'},
+                                    'functions': {'sample': {'includes': ['./']}}}
+
+    actual_manifest_definition = filter_manifest_definition(manifest_definition, 'sample')
+    assert actual_manifest_definition == expected_manifest_definition
+
+
+def test_partial_filter_manifest_definition():
+
+    manifest_definition = {'package': {'output': './build'},
                            'functions': {'sample-1': {'includes': ['./']},
                                          'sample-2': {'includes': ['./']},
+                                         'another-sample': {'includes': ['./']},
                                          'another': {'requirements': './requirements/dev.txt',
                                                      'include': ['./']}}}
     expected_manifest_definition = {'package': {'output': './build'},
                                     'functions': {'sample-1': {'includes': ['./']},
-                                                  'sample-2': {'includes': ['./']}}}
+                                                  'sample-2': {'includes': ['./']},
+                                                  'another-sample': {'includes': ['./']}}}
 
     actual_manifest_definition = filter_manifest_definition(manifest_definition, 'sample')
     assert actual_manifest_definition == expected_manifest_definition

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -83,11 +83,13 @@ def test_include_section_is_required():
 def test_filter_manifest_definition():
 
     manifest_definition = {'package': {'output': './build'},
-                           'functions': {'sample': {'includes': ['./']},
+                           'functions': {'sample-1': {'includes': ['./']},
+                                         'sample-2': {'includes': ['./']},
                                          'another': {'requirements': './requirements/dev.txt',
                                                      'include': ['./']}}}
     expected_manifest_definition = {'package': {'output': './build'},
-                                    'functions': {'sample': {'includes': ['./']}}}
+                                    'functions': {'sample-1': {'includes': ['./']},
+                                                  'sample-2': {'includes': ['./']}}}
 
     actual_manifest_definition = filter_manifest_definition(manifest_definition, 'sample')
     assert actual_manifest_definition == expected_manifest_definition


### PR DESCRIPTION
I use Juniper on a project with more than 20 lambda functions.

Instead of building every single function when running `juni build`, building a subset of these functions will help when I don't have very many new changes:
```
juni build --skip-clean --function-name auth
```